### PR TITLE
RCの使用の有無を設定できるオプションを追加

### DIFF
--- a/App/Inc/app.h
+++ b/App/Inc/app.h
@@ -14,6 +14,8 @@ int appInit(void);
 #define DD_USE_ENCODER2 0
 #define DD_NUM_OF_SV 0
 
+#define DD_USE_RC 1
+
 #include "DD_RC.h"
 #include "DD_MD.h"
 #include "DD_SV.h"

--- a/Drivers/SystemTasksManager/Src/SystemTaskManager.c
+++ b/Drivers/SystemTasksManager/Src/SystemTaskManager.c
@@ -166,13 +166,14 @@ int SY_init(void){
 
   appInit();
   
+#if DD_USE_RC
   message("msg", "wait for RC connection...");
   if( DD_RCInit((uint8_t*)g_rc_data, 100000) ){
     message("err", "RC initialize faild!\n");
     return EXIT_FAILURE;
   }
-  
   message("msg", "RC connected sucess");
+#endif
   
   /*initialize IWDG*/
   message("msg", "IWDG initialize");

--- a/Drivers/SystemTasksManager/Src/SystemTaskManager.c
+++ b/Drivers/SystemTasksManager/Src/SystemTaskManager.c
@@ -100,11 +100,13 @@ int main(void){
     while( g_SY_system_counter % _INTERVAL_MS != 0 ){
     }
     //もし一定時間以上応答がない場合はRCが切断されたとみなし、リセットをかけます。
+#if DD_USE_RC
     count_for_rc++;
     if(count_for_rc >= 20){
       message("err","RC disconnected!");
       while(1);
     }
+#endif
   }
 } /* main */
 


### PR DESCRIPTION
## 概要

`app.h` に、コントローラを使うか使わないかを定義する定数 `DD_USE_RC` を追加

```c
#define DD_USE_RC 1    // コントローラを使用する
#define DD_USE_RC 0    // コントローラを使用しない
```

コントローラ基板を外した状態での軽い動作確認を済ませてあります