### PR TITLE
I2C2の送信・受信をDMAに変更、I2C2の送信関数追加とそれに伴う関数名変更

### DIFF
--- a/App/Src/stm32f1xx_it.c
+++ b/App/Src/stm32f1xx_it.c
@@ -35,6 +35,7 @@
 #include "stm32f1xx.h"
 #include "stm32f1xx_it.h"
 #include "MW_USART.h"
+#include "MW_I2C.h"
 #include "SystemTaskManager.h"
 
 /******************************************************************************/
@@ -205,6 +206,31 @@ void USART2_IRQHandler(void)
   HAL_UART_IRQHandler(&huart2);
 }
 
+
+/**
+  * @brief  This function handles I2Cx interrupt request.
+  * @param  None
+  * @retval None
+  * @Note   This function is redefined in "main.h" and related to DMA
+  *         used for I2C data transmission
+  */
+
+void DMA1_Channel4_IRQHandler(void){
+  HAL_DMA_IRQHandler(hi2c2.hdmatx);
+}
+
+
+/**
+  * @brief  This function handles I2Cx interrupt request.
+  * @param  None
+  * @retval None
+  * @Note   This function is redefined in "main.h" and related to DMA
+  *         used for I2C data reception
+  */
+
+void DMA1_Channel5_IRQHandler(void){
+  HAL_DMA_IRQHandler(hi2c2.hdmarx);
+}
 /* USER CODE BEGIN 1 */
 
 /* USER CODE END 1 */

--- a/Drivers/DevDriver/AB/Src/DD_AB.c
+++ b/Drivers/DevDriver/AB/Src/DD_AB.c
@@ -30,7 +30,7 @@ int DD_send2AB(DD_ABHand_t *dab){
   data[1] = ~dab->dat;
 
   /* Send data */
-  return DD_I2CSend(dab->add, data, sizeof_data);
+  return DD_I2C1Send(dab->add, data, sizeof_data);
 }
 
 /*

--- a/Drivers/DevDriver/Gene/Inc/DD_Gene.h
+++ b/Drivers/DevDriver/Gene/Inc/DD_Gene.h
@@ -34,7 +34,8 @@ extern DD_SV_t g_sv_h;
 #endif
 
 /*I2Cのサポート用関数*/
-int DD_I2CSend(uint8_t add,const uint8_t *data,uint8_t size);
+int DD_I2C1Send(uint8_t add,const uint8_t *data,uint8_t size);
+int DD_I2C2Send(uint8_t add,const uint8_t *data, uint8_t size);
 int DD_I2C1Receive(uint8_t add, uint8_t *data, uint8_t size);
 int DD_I2C2Receive(uint8_t add, uint8_t *data, uint8_t size);
 /*Deviceのハンドラーの表示用関数*/

--- a/Drivers/DevDriver/Gene/Src/DD_Gene.c
+++ b/Drivers/DevDriver/Gene/Src/DD_Gene.c
@@ -21,8 +21,13 @@
 #include "message.h"
 
 /*I2Cのサポート用関数*/
-int DD_I2CSend(uint8_t add, const uint8_t *data, uint8_t size){
+int DD_I2C1Send(uint8_t add, const uint8_t *data, uint8_t size){
   int ret = MW_I2C1Transmit(add, data, size);
+  if(ret)message("err","trans faild at (%x) size %d,data[0]=%d",add,size,data[0]);
+  return ret;
+}
+int DD_I2C2Send(uint8_t add, const uint8_t *data, uint8_t size){
+  int ret = MW_I2C2Transmit(add, data, size);
   if(ret)message("err","trans faild at (%x) size %d,data[0]=%d",add,size,data[0]);
   return ret;
 }

--- a/Drivers/DevDriver/Gene/Src/DD_Gene.c
+++ b/Drivers/DevDriver/Gene/Src/DD_Gene.c
@@ -27,9 +27,8 @@ int DD_I2C1Send(uint8_t add, const uint8_t *data, uint8_t size){
   return ret;
 }
 int DD_I2C2Send(uint8_t add, const uint8_t *data, uint8_t size){
-  static Com_State_t state;
-  int ret = MW_I2C2Transmit(add, data, size, &state);
-  if(state==HAD_NOT_COMPLETED)message("warning","I2C2 transmit had not completed");
+  int ret = MW_I2C2Transmit(add, data, size);
+  if(!had_completed_tx)message("warning","I2C2 transmit had not completed");
   if(ret)message("err","I2C2 trans faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
   return ret;
 }
@@ -39,9 +38,8 @@ int DD_I2C1Receive(uint8_t add, uint8_t *data, uint8_t size){
   return ret;
 }
 int DD_I2C2Receive(uint8_t add, uint8_t *data, uint8_t size){
-  static Com_State_t state;
-  int ret = MW_I2C2Receive(add, data, size, &state);
-  if(state==HAD_NOT_COMPLETED)message("warning","I2C2 receive had not completed");
+  int ret = MW_I2C2Receive(add, data, size);
+  if(!had_completed_rx)message("warning","I2C2 receive had not completed");
   if(ret)message("err","I2C2 receive faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
   return ret;
 }

--- a/Drivers/DevDriver/Gene/Src/DD_Gene.c
+++ b/Drivers/DevDriver/Gene/Src/DD_Gene.c
@@ -23,19 +23,23 @@
 /*I2Cのサポート用関数*/
 int DD_I2C1Send(uint8_t add, const uint8_t *data, uint8_t size){
   int ret = MW_I2C1Transmit(add, data, size);
-  if(ret)message("err","trans faild at (%x) size %d,data[0]=%d",add,size,data[0]);
+  if(ret)message("err","I2C1 trans faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
   return ret;
 }
 int DD_I2C2Send(uint8_t add, const uint8_t *data, uint8_t size){
   int ret = MW_I2C2Transmit(add, data, size);
-  if(ret)message("err","trans faild at (%x) size %d,data[0]=%d",add,size,data[0]);
+  if(ret)message("err","I2C2 trans faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
   return ret;
 }
 int DD_I2C1Receive(uint8_t add, uint8_t *data, uint8_t size){
-  return MW_I2C1Receive(add, data, size);
+  int ret = MW_I2C1Receive(add, data, size);
+  if(ret)message("err","I2C1 receive faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
+  return ret;
 }
 int DD_I2C2Receive(uint8_t add, uint8_t *data, uint8_t size){
-  return MW_I2C2Receive(add, data, size);
+  int ret = MW_I2C2Receive(add, data, size);
+  if(ret)message("err","I2C1 receive faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
+  return ret;
 }
 
 /*DeviceDriverのタスク*/

--- a/Drivers/DevDriver/Gene/Src/DD_Gene.c
+++ b/Drivers/DevDriver/Gene/Src/DD_Gene.c
@@ -27,7 +27,9 @@ int DD_I2C1Send(uint8_t add, const uint8_t *data, uint8_t size){
   return ret;
 }
 int DD_I2C2Send(uint8_t add, const uint8_t *data, uint8_t size){
-  int ret = MW_I2C2Transmit(add, data, size);
+  static Com_State_t state;
+  int ret = MW_I2C2Transmit(add, data, size, &state);
+  if(state==HAD_NOT_COMPLETED)message("warning","I2C2 transmit had not completed");
   if(ret)message("err","I2C2 trans faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
   return ret;
 }
@@ -37,8 +39,10 @@ int DD_I2C1Receive(uint8_t add, uint8_t *data, uint8_t size){
   return ret;
 }
 int DD_I2C2Receive(uint8_t add, uint8_t *data, uint8_t size){
-  int ret = MW_I2C2Receive(add, data, size);
-  if(ret)message("err","I2C1 receive faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
+  static Com_State_t state;
+  int ret = MW_I2C2Receive(add, data, size, &state);
+  if(state==HAD_NOT_COMPLETED)message("warning","I2C2 receive had not completed");
+  if(ret)message("err","I2C2 receive faild \n addr:[%x],size:[%d],data:[0x%02x]",add,size,data[0]);
   return ret;
 }
 

--- a/Drivers/DevDriver/MD/Src/DD_MD.c
+++ b/Drivers/DevDriver/MD/Src/DD_MD.c
@@ -38,7 +38,7 @@ int DD_send2MD(DD_MDHand_t *dmd){
   data[1] = val;
 
   /* Send data */
-  return DD_I2CSend(dmd->add, data, sizeof_data);
+  return DD_I2C1Send(dmd->add, data, sizeof_data);
 }
 
 /*

--- a/Drivers/SystemTasksManager/Src/SystemTaskManager.c
+++ b/Drivers/SystemTasksManager/Src/SystemTaskManager.c
@@ -283,8 +283,10 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *UartHandle){
 
 void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c){
   UNUSED(hi2c);
+  MW_I2C2TransitionCompletedCallBack();
 }
 
 void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c){
   UNUSED(hi2c);
+  MW_I2C2ReceptionCompletedCallBack();
 }

--- a/Drivers/SystemTasksManager/Src/SystemTaskManager.c
+++ b/Drivers/SystemTasksManager/Src/SystemTaskManager.c
@@ -280,3 +280,11 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *UartHandle){
   UNUSED(UartHandle);
   MW_messageTransitionCompletedCallBack();
 }
+
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c){
+  UNUSED(hi2c);
+}
+
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c){
+  UNUSED(hi2c);
+}

--- a/Drivers/SystemTasksManager/Src/SystemTaskManager.c
+++ b/Drivers/SystemTasksManager/Src/SystemTaskManager.c
@@ -281,12 +281,12 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *UartHandle){
   MW_messageTransitionCompletedCallBack();
 }
 
-void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c){
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c){
   UNUSED(hi2c);
   MW_I2C2TransitionCompletedCallBack();
 }
 
-void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c){
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c){
   UNUSED(hi2c);
   MW_I2C2ReceptionCompletedCallBack();
 }

--- a/Drivers/middleLayers/I2C/Inc/MW_I2C.h
+++ b/Drivers/middleLayers/I2C/Inc/MW_I2C.h
@@ -22,6 +22,8 @@ typedef enum
     I2C2ID = 1,
   }i2cid_t;
 
+extern I2C_HandleTypeDef hi2c2;
+
 /**Saple code(main)
  *
  *

--- a/Drivers/middleLayers/I2C/Inc/MW_I2C.h
+++ b/Drivers/middleLayers/I2C/Inc/MW_I2C.h
@@ -24,6 +24,12 @@ typedef enum
 
 extern I2C_HandleTypeDef hi2c2;
 
+typedef enum{
+  HAD_COMPLETED = 0,
+  HAD_NOT_COMPLETED = -1,
+}Com_State_t;
+
+
 /**Saple code(main)
  *
  *
@@ -49,9 +55,9 @@ int MW_I2CInit(i2cid_t id);
 void MW_SetI2CClockSpeed(i2cid_t id,uint32_t ClockSpeed);
 
 int32_t MW_I2C1Transmit(uint8_t address,const uint8_t *data,uint16_t size);
-int32_t MW_I2C2Transmit(uint8_t address,const uint8_t *data,uint16_t size);
+int32_t MW_I2C2Transmit(uint8_t address,const uint8_t *data,uint16_t size,Com_State_t *state);
 int32_t MW_I2C1Receive(uint8_t address,uint8_t *data,uint16_t size);
-int32_t MW_I2C2Receive(uint8_t address,uint8_t *data,uint16_t size);
+int32_t MW_I2C2Receive(uint8_t address,uint8_t *data,uint16_t size,Com_State_t *state);
 void MW_I2C2TransitionCompletedCallBack(void);
 void MW_I2C2ReceptionCompletedCallBack(void);
 

--- a/Drivers/middleLayers/I2C/Inc/MW_I2C.h
+++ b/Drivers/middleLayers/I2C/Inc/MW_I2C.h
@@ -52,5 +52,7 @@ int32_t MW_I2C1Transmit(uint8_t address,const uint8_t *data,uint16_t size);
 int32_t MW_I2C2Transmit(uint8_t address,const uint8_t *data,uint16_t size);
 int32_t MW_I2C1Receive(uint8_t address,uint8_t *data,uint16_t size);
 int32_t MW_I2C2Receive(uint8_t address,uint8_t *data,uint16_t size);
+void MW_I2C2TransitionCompletedCallBack(void);
+void MW_I2C2ReceptionCompletedCallBack(void);
 
 #endif /* MIDLEWARE_INC_MW_I2C_H_ */

--- a/Drivers/middleLayers/I2C/Inc/MW_I2C.h
+++ b/Drivers/middleLayers/I2C/Inc/MW_I2C.h
@@ -9,6 +9,7 @@
 #define MIDLEWARE_INC_MW_I2C_H_
 
 #include "stm32f1xx_hal.h"
+#include <stdbool.h>
 
 typedef enum
   {
@@ -24,10 +25,13 @@ typedef enum
 
 extern I2C_HandleTypeDef hi2c2;
 
-typedef enum{
-  HAD_COMPLETED = 0,
-  HAD_NOT_COMPLETED = -1,
-}Com_State_t;
+/*DMA送信完了フラグを定義*/
+static
+volatile bool had_completed_tx = true;
+
+/*DMA受信完了フラグを定義*/
+static
+volatile bool had_completed_rx = true;
 
 
 /**Saple code(main)
@@ -55,9 +59,9 @@ int MW_I2CInit(i2cid_t id);
 void MW_SetI2CClockSpeed(i2cid_t id,uint32_t ClockSpeed);
 
 int32_t MW_I2C1Transmit(uint8_t address,const uint8_t *data,uint16_t size);
-int32_t MW_I2C2Transmit(uint8_t address,const uint8_t *data,uint16_t size,Com_State_t *state);
+int32_t MW_I2C2Transmit(uint8_t address,const uint8_t *data,uint16_t size);
 int32_t MW_I2C1Receive(uint8_t address,uint8_t *data,uint16_t size);
-int32_t MW_I2C2Receive(uint8_t address,uint8_t *data,uint16_t size,Com_State_t *state);
+int32_t MW_I2C2Receive(uint8_t address,uint8_t *data,uint16_t size);
 void MW_I2C2TransitionCompletedCallBack(void);
 void MW_I2C2ReceptionCompletedCallBack(void);
 

--- a/Drivers/middleLayers/I2C/Src/MW_I2C.c
+++ b/Drivers/middleLayers/I2C/Src/MW_I2C.c
@@ -8,9 +8,11 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+/*DMA送信完了フラグを定義*/
 static
 volatile bool had_completed_tx = true;
 
+/*DMA受信完了フラグを定義*/
 static
 volatile bool had_completed_rx = true;
 
@@ -68,15 +70,16 @@ int32_t MW_I2C1Transmit(uint8_t address, const uint8_t *data, uint16_t size){
 }
 
 int32_t MW_I2C2Transmit(uint8_t address, const uint8_t *data, uint16_t size, Com_State_t *state){
-  if(had_completed_tx){
+  if(had_completed_tx){ //送信完了フラグが立っていれば送信を行う
     if( HAL_I2C_Master_Transmit_DMA(&hi2c2, address << 1, (uint8_t*)data, size) != HAL_OK ){
       return -1;
     }
-    *state = HAD_COMPLETED;
-    had_completed_tx = false;
+    *state = HAD_COMPLETED;   //送信状態を完了にする
+    had_completed_tx = false; //送信完了フラグを下げる
     return 0;
   }else{
     *state = HAD_NOT_COMPLETED;
+    //送信完了フラグが立っていなければ、送信状態を未完了にする
     return 0;
   }
 }
@@ -89,23 +92,26 @@ int32_t MW_I2C1Receive(uint8_t address, uint8_t *data, uint16_t size){
 }
 
 int32_t MW_I2C2Receive(uint8_t address, uint8_t *data, uint16_t size, Com_State_t *state){
-  if(had_completed_rx){
+  if(had_completed_rx){ //受信完了フラグが立っていれば受信を行う
     if( HAL_I2C_Master_Receive_DMA(&hi2c2, address << 1, data, size) != HAL_OK ){
       return -1;
     }
-    *state = HAD_COMPLETED;
-    had_completed_rx = false;
+    *state = HAD_COMPLETED;   //受信状態を完了にする
+    had_completed_rx = false; //受信完了フラグを下げる
     return 0;
   }else{
     *state = HAD_NOT_COMPLETED;
+    //受信完了フラグが立っていなければ、受信状態を未完了にする
     return 0;
   }
 }
 
+//送信コールバックによって送信完了フラグを立てる関数
 void MW_I2C2TransitionCompletedCallBack(void){
   had_completed_tx = true;
 }
 
+//受信コールバックによって受信完了フラグを立てる関数
 void MW_I2C2ReceptionCompletedCallBack(void){
   had_completed_rx = true;
 }

--- a/Drivers/middleLayers/I2C/Src/MW_I2C.c
+++ b/Drivers/middleLayers/I2C/Src/MW_I2C.c
@@ -20,7 +20,7 @@ static I2C_HandleTypeDef hi2c1 = {
     .NoStretchMode = I2C_NOSTRETCH_DISABLE,
   }
 };
-static I2C_HandleTypeDef hi2c2 = {
+I2C_HandleTypeDef hi2c2 = {
   .Instance = I2C2,
   .Init = {
     .ClockSpeed = 100000,
@@ -60,7 +60,7 @@ int32_t MW_I2C1Transmit(uint8_t address, const uint8_t *data, uint16_t size){
 }
 
 int32_t MW_I2C2Transmit(uint8_t address, const uint8_t *data, uint16_t size){
-  if( HAL_I2C_Master_Transmit(&hi2c2, address << 1, (uint8_t*)data, size, 10) != HAL_OK ){
+  if( HAL_I2C_Master_Transmit_DMA(&hi2c2, address << 1, (uint8_t*)data, size) != HAL_OK ){
     return -1;
   }
   return 0;
@@ -74,7 +74,7 @@ int32_t MW_I2C1Receive(uint8_t address, uint8_t *data, uint16_t size){
 }
 
 int32_t MW_I2C2Receive(uint8_t address, uint8_t *data, uint16_t size){
-  if( HAL_I2C_Master_Receive(&hi2c2, address << 1, data, size, 10) != HAL_OK ){
+  if( HAL_I2C_Master_Receive_DMA(&hi2c2, address << 1, data, size) != HAL_OK ){
     return -1;
   }
   return 0;

--- a/Drivers/middleLayers/I2C/Src/MW_I2C.c
+++ b/Drivers/middleLayers/I2C/Src/MW_I2C.c
@@ -5,17 +5,7 @@
  *      Author: evaota
  */
 #include "MW_I2C.h"
-#include <stdbool.h>
 #include <stdlib.h>
-
-/*DMA送信完了フラグを定義*/
-static
-volatile bool had_completed_tx = true;
-
-/*DMA受信完了フラグを定義*/
-static
-volatile bool had_completed_rx = true;
-
 
 static I2C_HandleTypeDef hi2c1 = {
   .Instance = I2C1,
@@ -69,19 +59,14 @@ int32_t MW_I2C1Transmit(uint8_t address, const uint8_t *data, uint16_t size){
   return 0;
 }
 
-int32_t MW_I2C2Transmit(uint8_t address, const uint8_t *data, uint16_t size, Com_State_t *state){
+int32_t MW_I2C2Transmit(uint8_t address, const uint8_t *data, uint16_t size){
   if(had_completed_tx){ //送信完了フラグが立っていれば送信を行う
     if( HAL_I2C_Master_Transmit_DMA(&hi2c2, address << 1, (uint8_t*)data, size) != HAL_OK ){
       return -1;
     }
-    *state = HAD_COMPLETED;   //送信状態を完了にする
     had_completed_tx = false; //送信完了フラグを下げる
-    return 0;
-  }else{
-    *state = HAD_NOT_COMPLETED;
-    //送信完了フラグが立っていなければ、送信状態を未完了にする
-    return 0;
   }
+  return 0;
 }
 
 int32_t MW_I2C1Receive(uint8_t address, uint8_t *data, uint16_t size){
@@ -91,19 +76,14 @@ int32_t MW_I2C1Receive(uint8_t address, uint8_t *data, uint16_t size){
   return 0;
 }
 
-int32_t MW_I2C2Receive(uint8_t address, uint8_t *data, uint16_t size, Com_State_t *state){
+int32_t MW_I2C2Receive(uint8_t address, uint8_t *data, uint16_t size){
   if(had_completed_rx){ //受信完了フラグが立っていれば受信を行う
     if( HAL_I2C_Master_Receive_DMA(&hi2c2, address << 1, data, size) != HAL_OK ){
       return -1;
     }
-    *state = HAD_COMPLETED;   //受信状態を完了にする
     had_completed_rx = false; //受信完了フラグを下げる
-    return 0;
-  }else{
-    *state = HAD_NOT_COMPLETED;
-    //受信完了フラグが立っていなければ、受信状態を未完了にする
-    return 0;
   }
+  return 0;
 }
 
 //送信コールバックによって送信完了フラグを立てる関数

--- a/Drivers/middleLayers/I2C/Src/MW_I2C.c
+++ b/Drivers/middleLayers/I2C/Src/MW_I2C.c
@@ -5,7 +5,15 @@
  *      Author: evaota
  */
 #include "MW_I2C.h"
+#include <stdbool.h>
 #include <stdlib.h>
+
+static
+volatile bool had_completed_tx = true;
+
+static
+volatile bool had_completed_rx = true;
+
 
 static I2C_HandleTypeDef hi2c1 = {
   .Instance = I2C1,
@@ -60,8 +68,12 @@ int32_t MW_I2C1Transmit(uint8_t address, const uint8_t *data, uint16_t size){
 }
 
 int32_t MW_I2C2Transmit(uint8_t address, const uint8_t *data, uint16_t size){
-  if( HAL_I2C_Master_Transmit_DMA(&hi2c2, address << 1, (uint8_t*)data, size) != HAL_OK ){
-    return -1;
+  if(had_completed_tx){
+    if( HAL_I2C_Master_Transmit_DMA(&hi2c2, address << 1, (uint8_t*)data, size) != HAL_OK ){
+      return -1;
+    }
+    had_completed_tx = false;
+    return 0;
   }
   return 0;
 }
@@ -74,9 +86,20 @@ int32_t MW_I2C1Receive(uint8_t address, uint8_t *data, uint16_t size){
 }
 
 int32_t MW_I2C2Receive(uint8_t address, uint8_t *data, uint16_t size){
-  if( HAL_I2C_Master_Receive_DMA(&hi2c2, address << 1, data, size) != HAL_OK ){
-    return -1;
+  if(had_completed_rx){
+    if( HAL_I2C_Master_Receive_DMA(&hi2c2, address << 1, data, size) != HAL_OK ){
+      return -1;
+    }
+    had_completed_rx = false;
+    return 0;
   }
   return 0;
 }
 
+void MW_I2C2TransitionCompletedCallBack(void){
+  had_completed_tx = true;
+}
+
+void MW_I2C2ReceptionCompletedCallBack(void){
+  had_completed_rx = true;
+}

--- a/Drivers/middleLayers/I2C/Src/MW_I2C.c
+++ b/Drivers/middleLayers/I2C/Src/MW_I2C.c
@@ -67,15 +67,18 @@ int32_t MW_I2C1Transmit(uint8_t address, const uint8_t *data, uint16_t size){
   return 0;
 }
 
-int32_t MW_I2C2Transmit(uint8_t address, const uint8_t *data, uint16_t size){
+int32_t MW_I2C2Transmit(uint8_t address, const uint8_t *data, uint16_t size, Com_State_t *state){
   if(had_completed_tx){
     if( HAL_I2C_Master_Transmit_DMA(&hi2c2, address << 1, (uint8_t*)data, size) != HAL_OK ){
       return -1;
     }
+    *state = HAD_COMPLETED;
     had_completed_tx = false;
     return 0;
+  }else{
+    *state = HAD_NOT_COMPLETED;
+    return 0;
   }
-  return 0;
 }
 
 int32_t MW_I2C1Receive(uint8_t address, uint8_t *data, uint16_t size){
@@ -85,15 +88,18 @@ int32_t MW_I2C1Receive(uint8_t address, uint8_t *data, uint16_t size){
   return 0;
 }
 
-int32_t MW_I2C2Receive(uint8_t address, uint8_t *data, uint16_t size){
+int32_t MW_I2C2Receive(uint8_t address, uint8_t *data, uint16_t size, Com_State_t *state){
   if(had_completed_rx){
     if( HAL_I2C_Master_Receive_DMA(&hi2c2, address << 1, data, size) != HAL_OK ){
       return -1;
     }
+    *state = HAD_COMPLETED;
     had_completed_rx = false;
     return 0;
+  }else{
+    *state = HAD_NOT_COMPLETED;
+    return 0;
   }
-  return 0;
 }
 
 void MW_I2C2TransitionCompletedCallBack(void){


### PR DESCRIPTION
# 題名
I2C2の送信・受信をDMAに変更、I2C2の送信関数追加とそれに伴う関数名変更

## 概要
I2C2のデータ送信と受信をDMAによって行うための設定などの追加を行いました。
また、I2C2の送信関数を追加し、I2C1と関数名を区別するためにDD_I2C1Send、DD_I2C2Sendと送信関数名に番号を追加し、それに伴いDD_I2C1Sendの元であるDD_I2CSendを用いていた関数名をDD_I2C1Sendに変更を致しました。

## テスト項目と検証が必要な項目
###基本的な部分
- [ ] コードは整形されてるか
- [ ] コードは適切な関数わけされてるか
- [ ] 命名は適切か
- [ ] 定数回で終了が保証されてるか
- [ ] その他に安全ではないことはないか

### その他

## その他
MDを2枚、センサを1つ接続した状態で軽い動作確認済みです。

### 見て欲しいところ
元々追加されているUARTのDMA送信の設定を参考にして追加させていただいたので、特に、App/Src/msp.c 内に追加した部分の修正点や、不適切な書き方、その他問題点などが存在するかもしれないのでご確認のほど宜しくお願いいたします。
